### PR TITLE
Implement experimental as-you-type linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 <!-- Plugin description -->
 Runs Packwerk in the background and adds error annotations to Ruby source files.
 
-Note: The linter can only run when the current file is saved to disk.
+Note: By default, the linter can only run when the current file is saved to disk. There's an experimental mode
+to enable as-you-type linting, but it's not widely supported.
 <!-- Plugin description end -->
 
 ## Installation

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.vinted.packwerkintellij
 pluginName = packwerk-intellij
 pluginRepositoryUrl = https://github.com/vinted/packwerk-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.3
+pluginVersion = 0.0.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/kotlin/com/vinted/packwerkintellij/PackwerkSettingsConfigurable.kt
+++ b/src/main/kotlin/com/vinted/packwerkintellij/PackwerkSettingsConfigurable.kt
@@ -11,28 +11,41 @@ import com.intellij.ui.dsl.builder.panel
 class PackwerkSettingsConfigurable(private val project: Project) : BoundConfigurable("Packwerk Settings") {
     private var packwerkPath: String = ""
     private var enabled = true
+    private var lintUnsavedFiles = false
 
     override fun createPanel(): DialogPanel = panel {
         val settings = project.service<PackwerkSettingsState>()
         packwerkPath = settings.packwerkPath
         enabled = settings.enabled
+        lintUnsavedFiles = settings.lintUnsavedFiles
 
-        row {
-            checkBox("Run Packwerk check")
-                .bindSelected(::enabled)
-                .comment("Note: The linter can only run when the current file is saved to disk.")
-        }
         row("Packwerk path:") {
             textField()
                 .bindText(::packwerkPath)
-                .comment("Note: This only accepts a single path. " +
-                        "The path can be absolute or relative to the project root. " +
-                        "Shell expansions or multiple arguments are not supported.")
+                .comment(
+                    "Note: This only accepts a single path. " +
+                            "The path can be absolute or relative to the project root. " +
+                            "Shell expansions or multiple arguments are not supported."
+                )
+        }
+        row {
+            checkBox("Lint Ruby files")
+                .bindSelected(::enabled)
+        }
+        row {
+            checkBox("Experimental: Lint unsaved files")
+                .bindSelected(::lintUnsavedFiles)
+                .comment(
+                    "This enables as-you-type linting. " +
+                            "Warning: this requires the linter to support the 'check-contents' command " +
+                            "which is currently only supported by Packs and not Packwerk."
+                )
         }
 
         onApply {
             settings.packwerkPath = packwerkPath
             settings.enabled = enabled
+            settings.lintUnsavedFiles = lintUnsavedFiles
         }
     }
 }

--- a/src/main/kotlin/com/vinted/packwerkintellij/PackwerkSettingsState.kt
+++ b/src/main/kotlin/com/vinted/packwerkintellij/PackwerkSettingsState.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.components.*
 class PackwerkSettingsState : PersistentStateComponent<PackwerkSettingsState> {
     var packwerkPath: String = "bin/packwerk"
     var enabled = true
+    var lintUnsavedFiles = false
 
     override fun getState(): PackwerkSettingsState {
         return this
@@ -18,5 +19,6 @@ class PackwerkSettingsState : PersistentStateComponent<PackwerkSettingsState> {
     override fun loadState(state: PackwerkSettingsState) {
         this.packwerkPath = state.packwerkPath
         this.enabled = state.enabled
+        this.lintUnsavedFiles = state.lintUnsavedFiles
     }
 }


### PR DESCRIPTION
This adds an experimental opt-in mode to use [the check-contents command](https://github.com/alexevanczuk/packs/pull/75) that allows linting unsaved files.