### PR TITLE
Restore build plugin step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           ./gradlew patchChangelog --release-note="$CHANGELOG"
 
+      # Build plugin
+      - name: Build plugin
+        run: ./gradlew buildPlugin
+
       # Publish the plugin to JetBrains Marketplace
       - name: Publish Plugin
         if: false


### PR DESCRIPTION
This step was mistakenly deleted in https://github.com/vinted/packwerk-intellij/pull/11.