### PR TITLE
Enable Publish Plugin step [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,8 @@ jobs:
         run: |
           ./gradlew patchChangelog --release-note="$CHANGELOG"
 
-      # Build plugin
-      - name: Build plugin
-        run: ./gradlew buildPlugin
-
       # Publish the plugin to JetBrains Marketplace
       - name: Publish Plugin
-        if: false
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}


### PR DESCRIPTION
This will allow us to publish new versions of this plugin automatically.