### PR TITLE
Fix top-level constant reference highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Top-level constant references are now highlighted correctly (#18)
+
 ## [0.0.5] - 2023-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 - Top-level constant references are now highlighted correctly (#18)
 
 ## [0.0.5] - 2023-08-01

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.vinted.packwerkintellij
 pluginName = packwerk-intellij
 pluginRepositoryUrl = https://github.com/vinted/packwerk-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.5
+pluginVersion = 0.0.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/kotlin/com/vinted/packwerkintellij/annotators/PackwerkAnnotator.kt
+++ b/src/main/kotlin/com/vinted/packwerkintellij/annotators/PackwerkAnnotator.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiFile
 import com.vinted.packwerkintellij.PackwerkSettingsState
 import org.intellij.markdown.lexer.push
 import org.jetbrains.plugins.ruby.ruby.lang.psi.references.RColonReference
+import org.jetbrains.plugins.ruby.ruby.lang.psi.references.RTopConstReference
 import org.jetbrains.plugins.ruby.ruby.lang.psi.variables.RConstant
 import java.nio.charset.Charset
 import java.util.*
@@ -144,7 +145,10 @@ internal class PackwerkAnnotator : ExternalAnnotator<PackwerkAnnotator.State, Pa
             var el = file.findElementAt(offset)
 
             // Expand compound constants (e.g. Foo::Bar)
-            while (el != null && (el.parent is RConstant || el.parent is RColonReference)) {
+            while (
+                el != null &&
+                (el.parent is RConstant || el.parent is RColonReference || el.parent is RTopConstReference)
+            ) {
                 el = el.parent
             }
 


### PR DESCRIPTION
When displaying violations for top-level const references, e.g. `::Foo`, only the `::` would get highlighted. With this change, `::Foo` gets highlighted.