### PR TITLE
Upgrade RubyMine support and gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ pluginGroup = com.vinted.packwerkintellij
 pluginName = packwerk-intellij
 pluginRepositoryUrl = https://github.com/vinted/packwerk-intellij
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.6
+pluginVersion = 0.0.7
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 232.*
+pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ annotations = "24.0.1"
 # plugins
 kotlin = "1.9.0"
 changelog = "2.1.2"
-gradleIntelliJPlugin = "1.15.0"
+gradleIntelliJPlugin = "1.16.1"
 qodana = "0.1.13"
 kover = "0.7.3"
 


### PR DESCRIPTION
This PR upgrades the supported IntelliJ/Rubymine version to be `233.*` since that is now available.

It also upgrades the gradle plugin version to deal with a build warning.

Since this would generate a new plugin version, it also increments to `0.0.7`.